### PR TITLE
Replace all the kulfi-project/kulfi to fastn-stack/kulfi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 - `malai {http, tcp}-bridge`: `port` is now optional, if you don't provide a
   port, it will be assigned a random port.
 - fix: [malai tcp bridge was only handling one concurrent
-  connection](https://github.com/kulfi-project/kulfi/issues/61), now it can
+  connection](https://github.com/fastn-stack/kulfi/issues/61), now it can
   handle multiple connections.
 
 ## 14 May 2025
@@ -38,7 +38,7 @@
 - fixed: `malai http-bridge` used to not cleanly exit because iroh connection
   cleanup was buggy.
 
-[1]: https://github.com/kulfi-project/kulfi/issues/60
+[1]: https://github.com/fastn-stack/kulfi/issues/60
 
 ## 06 May 2025
 
@@ -60,7 +60,7 @@
   optional when we have access control.
 - `malai.sh/install.sh`: refuse to install on non-Apple M series Macs. This is
   to prevent segfaults on Intel Macs. See [issue
-  #28](https://github.com/kulfi-project/kulfi/issues/28).
+  #28](https://github.com/fastn-stack/kulfi/issues/28).
 
 ## 23 April 2025
 
@@ -71,16 +71,16 @@ release binary to be only available for **Apple M series Macs (arm64)**. This
 is done because the x86_64 build is segfaulting when run on intel macs and we
 can't figure out the cause.
 
-More details at: https://github.com/kulfi-project/kulfi/issues/28
+More details at: https://github.com/fastn-stack/kulfi/issues/28
 
 ## 22 April 2025
 
 ### malai 0.2.0
 
 - Feat: `ctrl+c` to print info. Quick succession of `ctrl+c` within 3 seconds to
-  exit. [More details](https://github.com/kulfi-project/kulfi/discussions/9)
+  exit. [More details](https://github.com/fastn-stack/kulfi/discussions/9)
 - Feat: Configurable HTTP bridge address in the
-  output. [More details](https://github.com/kulfi-project/kulfi/discussions/17)
+  output. [More details](https://github.com/fastn-stack/kulfi/discussions/17)
 - Breaking: Rename subcommands `expose-http` -> `http` and `expose-tcp` ->
   `tcp`.
 - Breaking [Networking Internals]: Merged `Protocol::Identity` with

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Kulfi & Malai
 
-It is recommended to first open a [discussion](https://github.com/kulfi-project/kulfi/discussions) to discuss your ideas, before opening a pull request. This helps us to understand your changes better, and also helps you to get feedback on your changes before you spend time on implementing them.
+It is recommended to first open a [discussion](https://github.com/fastn-stack/kulfi/discussions) to discuss your ideas, before opening a pull request. This helps us to understand your changes better, and also helps you to get feedback on your changes before you spend time on implementing them.
 
 ## Building from source
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 edition = "2024"
 license = "UPL-1.0"
-repository = "https://github.com/kulfi-project/kulfi"
+repository = "https://github.com/fastn-stack/kulfi"
 homepage = "https://kulfi.app"
 publish = true
 rust-version = "1.87"  # update this when you update rust-toolchain.toml

--- a/kulfi.app/index.ftd
+++ b/kulfi.app/index.ftd
@@ -15,6 +15,6 @@ Docs: [/doc/](/doc/)
 
 Discord: [kulfi.app/discord/](/discord/)
 
-Github: https://github.com/kulfi-project/kulfi
+Github: https://github.com/fastn-stack/kulfi
 
 -- end: ds.site-page

--- a/kulfi.app/manifesto.ftd
+++ b/kulfi.app/manifesto.ftd
@@ -107,7 +107,7 @@ Kulfi is a public infrastructure project, built in the open. We’re looking for
 
 We’re not starting from scratch—we’re already building.
 
-Join us on [GitHub](https://github.com/kulfi-project/kulfi) and
+Join us on [GitHub](https://github.com/fastn-stack/kulfi) and
 [fastn.com](https://fastn.com). Join our discussions. Build with us.
 
 -- ds.heading-medium: 🌱 Let’s Rebuild the Internet—Together

--- a/malai.sh/blog/hello-tcp.ftd
+++ b/malai.sh/blog/hello-tcp.ftd
@@ -21,7 +21,7 @@ inset if { ftd.device == "mobile" }: $ds.spaces.inset-square.small
 
 -- ds.copy-regular:
 
-[`malai-0.2.5`](https://github.com/kulfi-project/kulfi/releases/) is out now!
+[`malai-0.2.5`](https://github.com/fastn-stack/kulfi/releases/) is out now!
 It brings a new feature to share your local TCP server with the world!
 
 Now you can share any TCP-based service running locally — including your
@@ -157,7 +157,7 @@ src: $assets.files.assets.malai-folder-browser-view.png
 We're just getting started, and your support means a lot.
 
 If you like what we're building, consider [starring the
-repo](https://github.com/kulfi-project/kulfi) on GitHub. It helps others
+repo](https://github.com/fastn-stack/kulfi) on GitHub. It helps others
 discover the project and keeps us motivated to build more!
 
 -- end: ds.section-column

--- a/malai.sh/blog/hello-world.ftd
+++ b/malai.sh/blog/hello-world.ftd
@@ -17,7 +17,7 @@ inset if { ftd.device == "mobile" }: $ds.spaces.inset-square.small
 
 -- ds.copy-regular:
 
-[`malai`](https://github.com/kulfi-project/kulfi) is a new open-source tool
+[`malai`](https://github.com/fastn-stack/kulfi) is a new open-source tool
 from the team at [FifthTry](https://fifthtry.com/team/). It helps you share
 your local HTTP server with the world — instantly and securely.
 
@@ -73,16 +73,16 @@ See the [Getting Started guide](/get-started/) or run `malai --help` to explore 
 
 Here are just a few things you can do with `malai`:
 
-- **User Acceptance Testing**  
+- **User Acceptance Testing**
   Share your in-progress app with non-technical stakeholders without pushing to staging.
-  
-- **HTTPS Testing**  
+
+- **HTTPS Testing**
   Test HTTPS-only features like Service Workers and OAuth callbacks with a trusted remote URL.
-  
-- **Webhook Testing**  
+
+- **Webhook Testing**
   Test Stripe, GitHub, or any other webhook provider locally, without deploying your backend.
 
-- **Developer Preview**  
+- **Developer Preview**
   Send a URL to your teammate to get feedback on your frontend work before merging.
 
 All this without any config, DNS setup, or cloud deploys.
@@ -110,12 +110,12 @@ it.
 We're actively working on expanding what you can do with `malai`. Here’s a peek
 at what’s coming:
 
-- Share any **TCP server**, not just HTTP  
+- Share any **TCP server**, not just HTTP
   Soon you'll be able to share any TCP-based service running locally —
   including your Postgres database, Redis, or even a custom TCP protocol — using
   the same seamless workflow.
 
-- Native support for **SSH** using `malai ssh`  
+- Native support for **SSH** using `malai ssh`
   We're adding support for secure shell access over P2P with `malai ssh`. This
   will let you remotely access your development machine or share a shell session
   without needing public IPs or VPNs.
@@ -133,13 +133,13 @@ friends, or devices across your network, Kulfi will give you visibility and
 control.
 
 You can learn more about our plans for `kulfi` and `malai` on our [GitHub
-Discussions](https://github.com/kulfi-project/kulfi/discussions) page.
+Discussions](https://github.com/fastn-stack/kulfi/discussions) page.
 
 -- ds.copy-regular:
 
 Stay tuned — and if you have ideas, feature requests, or want to contribute,
 feel free to open an issue or pull request on
-[GitHub](https://github.com/kulfi-project/kulfi)! You can also join our
+[GitHub](https://github.com/fastn-stack/kulfi)! You can also join our
 [discord](https://discord.gg/nK4ZP8HpV7) and chat about the project.
 
 -- ds.heading-medium: Star us on GitHub ⭐
@@ -149,7 +149,7 @@ feel free to open an issue or pull request on
 We're just getting started, and your support means a lot.
 
 If you like what we're building, consider [starring the
-repo](https://github.com/kulfi-project/kulfi) on GitHub. It helps others
+repo](https://github.com/fastn-stack/kulfi) on GitHub. It helps others
 discover the project and keeps us motivated to build more!
 
 -- end: ds.section-column

--- a/malai.sh/components/header.ftd
+++ b/malai.sh/components/header.ftd
@@ -30,9 +30,9 @@ spacing: $ds.spaces.horizontal-gap.space-between
         -- ds.primary-button: Get Started
         link: /get-started/
 
-        -- ftd.image: 
+        -- ftd.image:
         src: $assets.files.assets.github.svg
-        link: https://github.com/kulfi-project/kulfi
+        link: https://github.com/fastn-stack/kulfi
         width.fixed.px: 24
         height.fixed.px: 24
         padding-top.px: 4

--- a/malai.sh/components/hero.ftd
+++ b/malai.sh/components/hero.ftd
@@ -39,11 +39,11 @@ Or use: malai browse kulfi://pubqaksutn9im0ncln2bki3i8diekh3sr4vp94o2cg1agjrb8dh
 
 
 -- ds.copy-small: ⭐️ Star us on GitHub
-link: https://github.com/kulfi-project/kulfi
+link: https://github.com/fastn-stack/kulfi
 style: bold
 color: $ds.colors.accent.primary
 
--- end: ds.column 
+-- end: ds.column
 
 -- end: ds.column
 
@@ -78,11 +78,11 @@ lang: bash
 \curl -fsSL https://malai.sh/install.sh | sh
 
 -- ds.copy-regular: ⭐️ Star us on GitHub
-link: https://github.com/kulfi-project/kulfi
+link: https://github.com/fastn-stack/kulfi
 style: bold
 color: $ds.colors.accent.primary
 
--- end: ds.column 
+-- end: ds.column
 
 -- ds.image:
 src: $assets.files.assets.demo.svg

--- a/malai.sh/doc/get-started.ftd
+++ b/malai.sh/doc/get-started.ftd
@@ -20,7 +20,7 @@ id: install
 -- ds.heading-small: MacOS/Linux
 
 Run the following command in your terminal. Alternatively, you can download the
-binaries directly from [GitHub Releases](https://github.com/kulfi-project/kulfi/releases/).
+binaries directly from [GitHub Releases](https://github.com/fastn-stack/kulfi/releases/).
 
 -- ds.code:
 lang: bash
@@ -29,7 +29,7 @@ lang: bash
 
 -- ds.heading-small: Windows
 
-- Download `malai_windows_x86_64.zip` file from [GitHub Releases](https://github.com/kulfi-project/kulfi/releases/).
+- Download `malai_windows_x86_64.zip` file from [GitHub Releases](https://github.com/fastn-stack/kulfi/releases/).
 - Unzip the file to a directory of your choice.
 - Add the directory to your system's `PATH` environment variable.
 
@@ -81,7 +81,7 @@ id: more
 id: help
 
 - Chat with us on [Discord](https://discord.gg/nK4ZP8HpV7)
-- Create a new discussion on [GitHub](https://github.com/kulfi-project/kulfi/discussions)
+- Create a new discussion on [GitHub](https://github.com/fastn-stack/kulfi/discussions)
 
 
 -- end: p.doc-page

--- a/malai.sh/doc/tcp.ftd
+++ b/malai.sh/doc/tcp.ftd
@@ -7,10 +7,10 @@ your database server or ssh server. Learn more about "malai tcp" on this page.
 
 -- ds.heading-large: `malai tcp`: Share a TCP Service Using `malai`
 
--- ds.copy-regular: 
+-- ds.copy-regular:
 
 Starting
-[`malai-0.2.3`](https://github.com/kulfi-project/kulfi/releases/tag/malai-0.2.3).
+[`malai-0.2.3`](https://github.com/fastn-stack/kulfi/releases/tag/malai-0.2.3).
 You can share your local TCP server with the world. This can be your database
 server or ssh server for example.
 

--- a/malai.sh/install.sh
+++ b/malai.sh/install.sh
@@ -135,7 +135,7 @@ setup() {
         mkdir -p "$DESTINATION_PATH"
     fi
 
-    URL="https://github.com/kulfi-project/kulfi/releases/download/malai-$MALAI_VERSION"
+    URL="https://github.com/fastn-stack/kulfi/releases/download/malai-$MALAI_VERSION"
     log_message "Installing malai $MALAI_VERSION in $DESTINATION_PATH."
 
     if [ "$(uname)" = "Darwin" ]; then
@@ -168,7 +168,7 @@ check_architecture() {
         ARCH=$(arch)
         if [ "$ARCH" != "arm64" ]; then
             log_error "Only Apple Silicon (arm64) is supported on macOS."
-            log_error "Subscribe to https://github.com/kulfi-project/kulfi/issues/28"
+            log_error "Subscribe to https://github.com/fastn-stack/kulfi/issues/28"
             log_error "to get notified when x86_64 support is added."
             exit 1
         fi


### PR DESCRIPTION
Simply replace `kulfi-project` to `fastn-stack`, so `install.sh` should work again.